### PR TITLE
apps: Update default Linux kernel, rootfs funcs

### DIFF
--- a/apps/x86/cma34cr_ubuntu/CMakeLists.txt
+++ b/apps/x86/cma34cr_ubuntu/CMakeLists.txt
@@ -19,7 +19,7 @@ include(${CAMKES_VM_LINUX_HELPERS_PATH})
 DeclareCAmkESVM(Init0)
 
 # Declare C162 Kernel
-GetDefaultLinuxKernelFile(kernel_file)
+GetArchSpecificLinuxKernelFile("32" kernel_file)
 DecompressLinuxKernel(extract_linux_kernel decompressed_kernel ${kernel_file})
 AddToFileServer("bzimage" ${decompressed_kernel} DEPENDS extract_linux_kernel)
 

--- a/apps/x86/optiplex9020/CMakeLists.txt
+++ b/apps/x86/optiplex9020/CMakeLists.txt
@@ -20,9 +20,9 @@ DeclareCAmkESVM(Init0 EXTRA_SOURCES ${init0_extra} EXTRA_LIBS ethdrivers)
 # Declare VM component: Init1
 DeclareCAmkESVM(Init1)
 
-# Get Default Linux VM files
-GetDefaultLinuxKernelFile(kernel_file)
-GetDefaultLinuxRootfsFile(rootfs_file)
+# Get 32-bit Linux VM files
+GetArchDefaultLinuxKernelFile("32" kernel_file)
+GetArchDefaultLinuxRootfsFile("32" rootfs_file)
 
 # Decompress Linux Kernel image
 DecompressLinuxKernel(extract_linux_kernel decompressed_kernel ${kernel_file})

--- a/apps/x86/zmq_samples/CMakeLists.txt
+++ b/apps/x86/zmq_samples/CMakeLists.txt
@@ -51,9 +51,9 @@ endforeach()
 
 DeclareCamkesComponent(virtqueueinit)
 
-# Get Default Linux VM files
-GetDefaultLinuxKernelFile(kernel_file)
-GetDefaultLinuxRootfsFile(rootfs_file)
+# Get 32-bit Linux VM files
+GetArchDefaultLinuxKernelFile("32" kernel_file)
+GetArchDefaultLinuxRootfsFile("32" rootfs_file)
 
 foreach(i RANGE ${NumberVMsLess1})
     AddFileToOverlayDir(


### PR DESCRIPTION
Since the applications don't have homogeneous host and guest
architectures, i.e. host is x86_64 and guest is ia32, we update the
CMakeLists.txt of these applications to use the new CMake function to
grab an architectural specific kernel and rootfs image.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>