### PR TITLE
github: add GH action for VM tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Actions to run on pull requests
+
+name: Camkes VM
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        march: [nehalem, armv7a, armv8a]
+    steps:
+    - uses: seL4/ci-actions/camkes-vm@master
+      with:
+        march: ${{ matrix.march }}


### PR DESCRIPTION
See also seL4/ci-actions#133 and seL4/ci-actions#132

Currently these are just the builds and the simulation run for ARMVIRT. Hardware runs to be added once the machine queue works again.

