### PR TITLE
github: run build test only on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@
 name: Camkes VM
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:
@@ -16,7 +14,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         march: [nehalem, armv7a, armv8a]
     steps:


### PR DESCRIPTION
The deployment chain already contains the build test, no need to run it twice.
