### PR TITLE
remove obsolete HAVE_AUTOCONF

### DIFF
--- a/apps/x86/cma34cr_centos/cma34cr_centos.camkes
+++ b/apps/x86/cma34cr_centos/cma34cr_centos.camkes
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#ifdef HAVE_AUTOCONF
-#include <autoconf.h>
-#endif
-
 import <VM/vm.camkes>;
 
 #include <configurations/vm.h>

--- a/apps/x86/minimal/minimal.camkes
+++ b/apps/x86/minimal/minimal.camkes
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#ifdef HAVE_AUTOCONF
-#include <autoconf.h>
-#endif
 import <VM/vm.camkes>;
 
 #include <configurations/vm.h>

--- a/apps/x86/optiplex9020/optiplex9020.camkes
+++ b/apps/x86/optiplex9020/optiplex9020.camkes
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#ifdef HAVE_AUTOCONF
-#include <autoconf.h>
-#endif
 import <VM/vm.camkes>;
 
 #include <configurations/vm.h>


### PR DESCRIPTION
Follow-up from comment https://github.com/seL4/seL4/pull/668#issuecomment-980834686

Seems `HAVE_AUTOCONF` is not set anywhere, so this looks like dead code. If this expects somebody else to set this, then this mechanism is broken.