### PR TITLE
arm: dereference linux

### DIFF
--- a/apps/Arm/odroid_vm/vm_odroid.camkes
+++ b/apps/Arm/odroid_vm/vm_odroid.camkes
@@ -212,16 +212,16 @@ assembly {
         uart_gcs.ID = 1;
         uart_px4.ID = 3;
 
-        vm.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
-        vm.linux_image_config = {};
+        vm.vm_image_config = {};
 
         vm.dtb = dtb([{"path": "/soc/chipid@10000000"},
                       {"path": "/soc/serial@12c20000"},

--- a/apps/Arm/vm_cross_connector/exynos5422/devices.camkes
+++ b/apps/Arm/vm_cross_connector/exynos5422/devices.camkes
@@ -17,18 +17,18 @@
 assembly {
 	composition {}
 	configuration {
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "serial2:115200n8",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "serial2:115200n8",
 
         };
 

--- a/apps/Arm/vm_cross_connector/qemu-arm-virt/devices.camkes
+++ b/apps/Arm/vm_cross_connector/qemu-arm-virt/devices.camkes
@@ -17,18 +17,18 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "/pl011@9000000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "/pl011@9000000",
         };
 
         vm0.dtb = dtb([

--- a/apps/Arm/vm_introspect/exynos5422/devices.camkes
+++ b/apps/Arm/vm_introspect/exynos5422/devices.camkes
@@ -20,19 +20,19 @@ assembly {
         vm_memdev.paddr = VM_RAM_BASE;
         vm_memdev.size = VM_RAM_SIZE;
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 earlyprintk=serial pci=nomsi",
-            "linux_stdout" : "serial2:115200n8",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 earlyprintk=serial pci=nomsi",
+            "kernel_stdout" : "serial2:115200n8",
         };
 
         vm0.dtb = dtb([{"path": "/firmware@2073000"},

--- a/apps/Arm/vm_introspect/qemu-arm-virt/devices.camkes
+++ b/apps/Arm/vm_introspect/qemu-arm-virt/devices.camkes
@@ -20,19 +20,19 @@ assembly {
         vm_memdev.paddr = VM_RAM_BASE;
         vm_memdev.size = VM_RAM_SIZE;
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "",
-            "linux_stdout" : "/pl011@9000000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "",
+            "kernel_stdout" : "/pl011@9000000",
         };
         vm0.num_vcpus = 2;
 

--- a/apps/Arm/vm_introspect/src/init_dataport_ram.c
+++ b/apps/Arm/vm_introspect/src/init_dataport_ram.c
@@ -12,8 +12,8 @@
 #include <sel4vmmplatsupport/guest_memory_util.h>
 #include <vmlinux.h>
 
-extern unsigned long linux_ram_base;
-extern unsigned long linux_ram_size;
+extern unsigned long ram_base;
+extern unsigned long ram_size;
 
 extern dataport_caps_handle_t memdev_handle;
 
@@ -23,12 +23,12 @@ static vm_frame_t dataport_memory_iterator(uintptr_t addr, void *cookie)
     vm_frame_t frame_result = { seL4_CapNull, seL4_NoRights, 0, 0 };
 
     uintptr_t frame_start = ROUND_DOWN(addr, BIT(seL4_PageBits));
-    if (frame_start < linux_ram_base || frame_start > linux_ram_base + linux_ram_size) {
+    if (frame_start < ram_base || frame_start > ram_base + ram_size) {
         ZF_LOGE("Error: Not dataport ram region");
         return frame_result;
     }
 
-    int page_idx = (frame_start - linux_ram_base) / BIT(seL4_PageBits);
+    int page_idx = (frame_start - ram_base) / BIT(seL4_PageBits);
     frame_result.cptr = dataport_get_nth_frame_cap(&memdev_handle, page_idx);
     frame_result.rights = seL4_AllRights;
     frame_result.vaddr = frame_start;
@@ -40,6 +40,6 @@ void init_ram_module(vm_t *vm, void *cookie)
 {
     int err;
 
-    err = vm_ram_register_at_custom_iterator(vm, linux_ram_base, linux_ram_size, dataport_memory_iterator, NULL);
+    err = vm_ram_register_at_custom_iterator(vm, ram_base, ram_size, dataport_memory_iterator, NULL);
     assert(!err);
 }

--- a/apps/Arm/vm_minimal/exynos5422/devices.camkes
+++ b/apps/Arm/vm_minimal/exynos5422/devices.camkes
@@ -18,19 +18,19 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 earlyprintk=serial pci=nomsi",
-            "linux_stdout" : "serial2:115200n8",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 earlyprintk=serial pci=nomsi",
+            "kernel_stdout" : "serial2:115200n8",
         };
 
         vm0.dtb = dtb([{"path": "/firmware@2073000"},

--- a/apps/Arm/vm_minimal/odroidc2/devices.camkes
+++ b/apps/Arm/vm_minimal/odroidc2/devices.camkes
@@ -17,17 +17,17 @@
 assembly {
     composition {}
     configuration {
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {};
+        vm0.vm_image_config = {};
 
         vm0.dtb = dtb([
                 {"path": "/serial@c81004c0"},

--- a/apps/Arm/vm_minimal/qemu-arm-virt/devices.camkes
+++ b/apps/Arm/vm_minimal/qemu-arm-virt/devices.camkes
@@ -17,19 +17,19 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "",
-            "linux_stdout" : "/pl011@9000000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "",
+            "kernel_stdout" : "/pl011@9000000",
         };
         vm0.num_vcpus = 2;
 

--- a/apps/Arm/vm_minimal/tk1/devices.camkes
+++ b/apps/Arm/vm_minimal/tk1/devices.camkes
@@ -18,19 +18,19 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_PADDR_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_PADDR_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttyS0,115200n8 otf_key=c75e5bb91eb3bd947560357b64422f85 usbcore.old_scheme_first=1 tegraid=40.1.1.0.0 modem_id=0 android.kerneltype=normal commchip_id=0 usb_port_owner_info=2 lane_owner_info=1 touch_id=0@0 board_info=0x0177:0x0000:0x02:0x43:0x00 init=/sbin/init root=/dev/mmcblk0p2 rw rootwait gpt earlyprint",
-            "linux_stdout" : "/pl011@9000000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttyS0,115200n8 otf_key=c75e5bb91eb3bd947560357b64422f85 usbcore.old_scheme_first=1 tegraid=40.1.1.0.0 modem_id=0 android.kerneltype=normal commchip_id=0 usb_port_owner_info=2 lane_owner_info=1 touch_id=0@0 board_info=0x0177:0x0000:0x02:0x43:0x00 init=/sbin/init root=/dev/mmcblk0p2 rw rootwait gpt earlyprint",
+            "kernel_stdout" : "/pl011@9000000",
         };
 
         vm0.dtb = dtb([{"path": "/interrupt-controller@60004000"},

--- a/apps/Arm/vm_minimal/tx1/devices.camkes
+++ b/apps/Arm/vm_minimal/tx1/devices.camkes
@@ -17,20 +17,20 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR),
         };
         vm0.num_vcpus = 4;
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttyS0,115200n8 earlycon=uart8250,mmio32,0x70006000 debug mem=100m initcall_debug user_debug=31",
-            "linux_stdout" : "serial0:115200n8",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttyS0,115200n8 earlycon=uart8250,mmio32,0x70006000 debug mem=100m initcall_debug user_debug=31",
+            "kernel_stdout" : "serial0:115200n8",
         };
 
         vm0.dtb = dtb([{"path": "/serial@70006000"},

--- a/apps/Arm/vm_minimal/tx2/devices.camkes
+++ b/apps/Arm/vm_minimal/tx2/devices.camkes
@@ -17,19 +17,19 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttyS0,115200n1 no_console_suspend=1 earlycon=uart8250,mmio32,0x03100000 debug init=/sbin/init",
-            "linux_stdout" : "/serial@3100000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttyS0,115200n1 no_console_suspend=1 earlycon=uart8250,mmio32,0x03100000 debug init=/sbin/init",
+            "kernel_stdout" : "/serial@3100000",
         };
         vm0.num_vcpus = 4;
 

--- a/apps/Arm/vm_multi/exynos5422/devices.camkes
+++ b/apps/Arm/vm_multi/exynos5422/devices.camkes
@@ -28,18 +28,18 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM0_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM0_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM0_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM0_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM0_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM0_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM0_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM0_INITRD_ADDR),
         };
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm0",
         };
@@ -64,18 +64,18 @@ assembly {
                        {"path": "/soc/system-controller@10040000"},
                       ]);
 
-        vm1.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM1_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM1_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM1_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm1.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM1_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM1_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM1_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM1_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM1_INITRD_ADDR),
         };
-        vm1.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm1.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm-client",
         };
@@ -89,18 +89,18 @@ assembly {
         vm1.irqs =  [];
         vm1.dtb = dtb([{}]);
 
-        vm2.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM2_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM2_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM2_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm2.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM2_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM2_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM2_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM2_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM2_INITRD_ADDR),
         };
-        vm2.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm2.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm-client",
         };

--- a/apps/Arm/vm_multi/qemu-arm-virt/devices.camkes
+++ b/apps/Arm/vm_multi/qemu-arm-virt/devices.camkes
@@ -28,18 +28,18 @@ assembly {
     composition {}
     configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM0_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM0_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM0_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM0_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM0_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM0_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM0_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM0_INITRD_ADDR),
         };
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm0",
         };
@@ -57,18 +57,18 @@ assembly {
                     ];
         vm0.dtb_irqs = [35, 36, 37, 38];
 
-        vm1.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM1_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM1_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM1_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm1.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM1_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM1_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM1_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM1_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM1_INITRD_ADDR),
         };
-        vm1.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm1.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm-client",
         };
@@ -80,18 +80,18 @@ assembly {
         ];
         vm1.dtb = dtb([{}]);
 
-        vm2.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM2_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM2_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM2_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm2.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM2_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM2_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM2_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM2_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM2_INITRD_ADDR),
         };
-        vm2.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm2.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 nosmp rw debug loglevel=8 pci=nomsi,realloc=off,bios initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
             "dtb_name" : "",
             "initrd_name" : "linux-initrd-vm-client",
         };

--- a/apps/Arm/vm_serial_server/exynos5422/devices.camkes
+++ b/apps/Arm/vm_serial_server/exynos5422/devices.camkes
@@ -17,19 +17,19 @@
 assembly {
 	composition {}
 	configuration {
-        vm.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm.linux_image_config = {
-            "linux_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=7 pci=nomsi initcall_debug initcall_blacklist=clk_disable_unused",
-            "linux_stdout" : "hvc0",
+        vm.vm_image_config = {
+            "kernel_bootcmdline" : "console=hvc0 root=/dev/ram0 nosmp rw debug loglevel=7 pci=nomsi initcall_debug initcall_blacklist=clk_disable_unused",
+            "kernel_stdout" : "hvc0",
         };
 
         vm.dtb = dtb([{"path": "/firmware@02073000"},

--- a/apps/Arm/vm_virtio_net/exynos5422/devices.camkes
+++ b/apps/Arm/vm_virtio_net/exynos5422/devices.camkes
@@ -17,19 +17,19 @@
 assembly {
 	composition {}
 	configuration {
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=7 earlyprintk=serial pci=nomsi",
-            "linux_stdout" : "serial2:115200n8",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttySAC2,115200n8 root=/dev/ram0 nosmp rw debug loglevel=7 earlyprintk=serial pci=nomsi",
+            "kernel_stdout" : "serial2:115200n8",
         };
 
         vm0.dtb = dtb([{"path": "/firmware@02073000"},

--- a/apps/Arm/vm_virtio_net/tx2/devices.camkes
+++ b/apps/Arm/vm_virtio_net/tx2/devices.camkes
@@ -17,19 +17,19 @@ assembly {
 	composition {}
 	configuration {
 
-        vm0.linux_address_config = {
-            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
-            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
-            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
             "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
             "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
             "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
         };
 
-        vm0.linux_image_config = {
-            "linux_bootcmdline" : "console=ttyS0,115200n1 no_console_suspend=1 earlycon=uart8250,mmio32,0x03100000 debug nosmp init=/sbin/init",
-            "linux_stdout" : "/serial@3100000",
+        vm0.vm_image_config = {
+            "kernel_bootcmdline" : "console=ttyS0,115200n1 no_console_suspend=1 earlycon=uart8250,mmio32,0x03100000 debug nosmp init=/sbin/init",
+            "kernel_stdout" : "/serial@3100000",
         };
 
         vm0.dtb = dtb([


### PR DESCRIPTION
This commit performed a find/replace to replace Linux references with generic VM/Kernel references, due to the VMM's ability to run other Operating Systems.

Test with: https://github.com/seL4/camkes-vm/pull/47