### PR TITLE
vm_introspect: fix build breaker and warning

### DIFF
--- a/apps/Arm/vm_introspect/src/cross_vm_connection.c
+++ b/apps/Arm/vm_introspect/src/cross_vm_connection.c
@@ -19,7 +19,7 @@
 #endif
 
 //example going from linux to native component
-static void sys_ipa_to_pa(void *cookie)
+static void sys_ipa_to_pa(void)
 {
     printf("address from linux is %x\n", *(seL4_Word *)introspect_data);
 


### PR DESCRIPTION
The changes from sel4/camkes-vm#48 and sel4/camkes-vm#62 have broken `vm_introspect`. This has not been noticed, because there is no CI coverage for it yet (https://github.com/seL4/camkes-vm-examples/issues/38). With this patch the build work locally for me again.