### PR TITLE
Remove affinity setting from optiplex example

### DIFF
--- a/apps/x86/optiplex9020/optiplex9020.camkes
+++ b/apps/x86/optiplex9020/optiplex9020.camkes
@@ -84,6 +84,5 @@ assembly {
         vm1.initrd_image = "rootfs.cpio";
         vm1.iospace_domain = 0x10;
         vm1.pci_devices_iospace = 2;
-        vm1.affinity = 1;
     }
 }


### PR DESCRIPTION
This example doesn't use a multicore configuration.