### PR TITLE
github: bump GitHub action versions

### DIFF
--- a/.github/workflows/camkes-vm-deploy.yml
+++ b/.github/workflows/camkes-vm-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -63,13 +63,13 @@ jobs:
     concurrency: camkes-hw-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ matrix.march }}
       - name: Run


### PR DESCRIPTION
Update to current node16 versions. The old node12 actions are deprecated and will stop working.