### PR TITLE
CI: don't run hardware test on forks

### DIFF
--- a/.github/workflows/camkes-vm-deploy.yml
+++ b/.github/workflows/camkes-vm-deploy.yml
@@ -55,6 +55,7 @@ jobs:
     name: Hardware
     runs-on: ubuntu-latest
     needs: [build]
+    if: ${{ github.repository_owner == 'seL4' }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +85,7 @@ jobs:
     name: Deploy manifest
     runs-on: ubuntu-latest
     needs: [code, hw-run]
+    if: ${{ github.repository_owner == 'seL4' }}
     steps:
     - name: Deploy
       uses: seL4/ci-actions/manifest-deploy@master


### PR DESCRIPTION
Forks usually don't have a valid token, so CI fail then.

We are doing this check in other repos also, so it seems good enough the fix the annoying warning on my fork evertime a rebase master. There are smarter ways to handle this, as forks could also have tokens - but that can be done when we have a fork that really does this.