### PR TITLE
CI: use commits from PR and not from master

### DIFF
--- a/.github/workflows/test-hw.yml
+++ b/.github/workflows/test-hw.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         manifest_repo: camkes-vm-examples-manifest
         manifest: master.xml
+        sha: ${{ github.event.pull_request.head.sha }}
 
   build:
     name: Build


### PR DESCRIPTION
This should have been in https://github.com/seL4/camkes-vm-examples/pull/60 already.