### PR TITLE
CI: don't have PR runs cancel each other

### DIFF
--- a/.github/workflows/test-hw.yml
+++ b/.github/workflows/test-hw.yml
@@ -17,6 +17,19 @@ on:
 permissions:
   contents: read
 
+# To reduce the load (especiually on the machine queue) we cancel any older runs
+# of this workflow for the current PR. Such runs exist, if there were new pushes
+# to the PR's branch without waiting for the workflow to finish. As a side
+# effect, pushing new commits now becomes a convenient way to cancel all the
+# older runs, e.g. if they are stuck and would only be stopped by the timeout
+# eventually.
+# Note that we could do the concurrency handling at a finer level, and only wrap
+# the actual run on the hardware. But there seems not much gain in letting the
+# older builds run, as these are usually obsolete with new pushes also.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   code:
     name: Freeze Code
@@ -75,8 +88,6 @@ jobs:
       fail-fast: true
       matrix:
         march: [nehalem, armv7a, armv8a]
-    # do not run concurrently with previous jobs in PRs, but do run concurrently in the build matrix
-    concurrency: camkes-hw-pr-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
         uses: actions/checkout@v4


### PR DESCRIPTION
Just cancel all older hardware runs for the current PR.

This fixes https://github.com/seL4/camkes-vm-examples/issues/65