### PR TITLE
CI: pick unique name for deployment workflow

### DIFF
--- a/.github/workflows/camkes-vm-deploy.yml
+++ b/.github/workflows/camkes-vm-deploy.yml
@@ -4,7 +4,7 @@
 
 # CAmkES VM regression tests
 
-name: Camkes VM
+name: Deploy
 
 on:
   push:


### PR DESCRIPTION
"Camkes VM" is also used in `.github/workflows/test.yml`. On the workflow status page it is a bit odd of there are two workflows with the name name. 