### PR TITLE
vm_minimal, zcu102: add petalinux 2022.1 support

### DIFF
--- a/apps/Arm/vm_minimal/zcu102/2022_1/devices.camkes
+++ b/apps/Arm/vm_minimal/zcu102/2022_1/devices.camkes
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <plat/smc.h>
+#include <configurations/vm.h>
+
+#define VM_INITRD_MAX_SIZE 0x1900000 //25 MB
+#define VM_RAM_BASE 0x10000000
+#define VM_RAM_SIZE 0x10000000
+#define VM_ENTRY_ADDR 0x10080000
+#define VM_RAM_OFFSET 0
+#define VM_DTB_ADDR 0x12000000
+#define VM_INITRD_ADDR 0x13000000
+
+assembly {
+    composition {}
+    configuration {
+
+        vm0.vm_address_config = {
+            "ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_paddr_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
+            "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR),
+            "kernel_entry_addr" : VAR_STRINGIZE(VM_ENTRY_ADDR),
+        };
+        vm0.num_vcpus = 4;
+
+        /* Extra untyped pool to allow for 256MB of RAM */
+        vm0.simple_untyped28_pool = 1;
+
+        vm0.vm_image_config = {
+            "kernel_name" : "linux",
+            "initrd_name" : "linux-initrd",
+            "dtb_base_name" : "linux-dtb",
+            "kernel_bootcmdline" : "console=ttyPS0,115200 root=/dev/ram rw earlycon clk_ignore_unused",
+            "kernel_stdout" : "serial0:115200n8",
+            "generate_dtb" : true,
+            "provide_dtb" : false,
+            "map_one_to_one" : false,
+            "provide_initrd": true,
+            "clean_cache" : false,
+        };
+
+        vm0.dtb = dtb([{"path": "/amba/serial@ff000000"} ]);
+
+        vm0.untyped_mmios = ["0xf9060000:12"]; // Interrupt Controller Virtual CPU interface (Virtual Machine view)
+
+        vm0.plat_keep_devices = [
+            "/pss_ref_clk",
+            "/gt_crx_ref_clk",
+            "/pss_alt_ref_clk",
+            "/aux_ref_clk",
+            "/video_clk",
+            "/pmu",
+            "/psci",
+            "/timer",
+            "/aliases",
+            "/axi/interrupt-controller@f9010000",
+            "/axi/serial@ff000000",
+        ];
+
+        vm0.plat_keep_devices_and_subtree = [
+            "/firmware",
+        ];
+
+        vm0.allow_smc = true;
+        vm0.allowed_smc_functions = [
+            SMC_PM_GET_API_VERSION,
+            SMC_PM_REQUEST_NODE,
+            SMC_PM_SET_REQUIREMENT,
+            SMC_PM_INIT_FINALIZE,
+            SMC_PM_FPGA_GET_STATUS,
+            SMC_PM_PINCTRL_REQUEST,
+            SMC_PM_PINCTRL_SET_FUNCTION,
+            SMC_PM_PINCTRL_CONFIG_PARAM_GET,
+            SMC_PM_PINCTRL_CONFIG_PARAM_SET,
+            SMC_PM_IOCTL,
+            SMC_PM_QUERY_DATA,
+            SMC_PM_CLOCK_ENABLE,
+            SMC_PM_CLOCK_GETSTATE,
+            SMC_PM_CLOCK_GETDIVIDER,
+            SMC_PM_CLOCK_GETPARENT,
+            SMC_PM_GET_TRUSTZONE_VERSION,
+            SMC_PM_ADD_SUBSYSTEM,
+            SMC_PM_FEATURE_CHECK,
+        ];
+    }
+}


### PR DESCRIPTION
See also https://github.com/seL4/camkes-vm-images/pull/8, https://github.com/seL4/camkes-vm/pull/129