### PR TITLE
github: pin Ubuntu 22.04 for deployment step

### DIFF
--- a/.github/workflows/camkes-vm-deploy.yml
+++ b/.github/workflows/camkes-vm-deploy.yml
@@ -82,7 +82,7 @@ jobs:
 
   deploy:
     name: Deploy manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [code, hw-run]
     if: ${{ github.repository_owner == 'seL4' }}
     steps:


### PR DESCRIPTION
Python 3.12 in Ubuntu 24.04 has incompatible packages.