### PR TITLE
arm,cmake: Set compiler expected tls settings

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -56,6 +56,11 @@ if(AppArch STREQUAL "Arm")
     # message(FATAL_ERROR "release is   ${RELEASE}")
     ApplyCommonReleaseVerificationSettings(${RELEASE} FALSE)
 
+    if (KernelSel4ArchAarch32)
+        # Set correct aarch32 TLS register config
+        set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+    endif()
+
     if(NOT CAMKES_VM_APP)
         message(
             FATAL_ERROR


### PR DESCRIPTION
Add the right TLS variable settings for the gnu-elf-abi used by our compilers.