### PR TITLE
vm_minimal: document/warn how to build for QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ The following example builds the CAmkES Arm VMM for the TK1. In the `build` dire
 ninja
 ```
 
-*Note: To buid for another platform you can substitute the value of the `-DPLATFORM` variable e.g. (exynos5422, tx1, tx2, zcu102, qemu-arm-virt)*
+*Note: To buid for another platform you can substitute the value of the `-DPLATFORM` variable e.g. (exynos5422, tx1, tx2, zcu102, qemu-arm-virt)*.
+
+For instance, on QEMU (which only supports AArch64), use:
+
+```sh
+../init-build.sh -DCAMKES_VM_APP=vm_minimal -DPLATFORM=qemu-arm-virt -DAARCH64=TRUE
+```
 
 An EFI application file will be left in `images/capdl-loader-image-arm-tk1` We normally boot using TFTP, by first copying `capdl-loader-image-arm-tk1` to a tftpserver then on the U-Boot serial console doing:
 

--- a/apps/Arm/vm_minimal/CMakeLists.txt
+++ b/apps/Arm/vm_minimal/CMakeLists.txt
@@ -84,7 +84,7 @@ elseif("${KernelARMPlatform}" STREQUAL "qemu-arm-virt")
     # Linux images for aarch64 only. However, it is unclear if that is the only
     # blocker to get this example run in QEMU on aarch32.
     if(NOT KernelSel4ArchAarch64)
-        message(FATAL_ERROR "Only AARCH64 is supported")
+        message(FATAL_ERROR "Only AARCH64 is supported on QEMU, set -DAARCH64=TRUE")
     endif()
 
     find_package(camkes-vm-linux REQUIRED)


### PR DESCRIPTION
This confused someone on the mailing list, so let's be explicit about how to do it for QEMU, which only supports AArch64.

Follow-up to https://github.com/seL4/camkes-vm-examples/pull/88 and because of [this mailing list post](https://lists.sel4.systems/hyperkitty/list/devel@sel4.systems/message/3IN5AVNQ6RUHDGQDNDHE26GGTB3RO3C6/).

I couldn't figure out how to modify `settings.cmake` in a nice way so that it defaulted to hypervisor mode in AArch32, but not for boards that don't support it, because that's a different seL4 architecture (unlike AArch64 where it's just a flag). So better documentation will have to do.