### PR TITLE
github: bump action versions

### DIFF
--- a/.github/workflows/camkes-vm-deploy.yml
+++ b/.github/workflows/camkes-vm-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -64,12 +64,12 @@ jobs:
     concurrency: camkes-hw-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: seL4/machine_queue
           path: machine_queue
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: images-${{ matrix.march }}
       - name: Run

--- a/.github/workflows/test-hw.yml
+++ b/.github/workflows/test-hw.yml
@@ -67,7 +67,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -90,12 +90,12 @@ jobs:
         march: [nehalem, armv7a, armv8a]
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: seL4/machine_queue
           path: machine_queue
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: images-${{ matrix.march }}
       - name: Run

--- a/apps/x86/cma34cr_centos/README.md
+++ b/apps/x86/cma34cr_centos/README.md
@@ -8,36 +8,40 @@
 
 ## Installation
 
-CentOS should be installed on the 32GiB flash drive of the cma34cr using the entire drive,
-i.e. no dual booting etc. It must be an i386 CentOS 7 installation, images of which can be
-found at http://mirror.centos.org/altarch/7/isos/i386/
+CentOS should be installed on the 32GiB flash drive of the `cma34cr` using the
+entire drive, i.e. no dual booting etc. It must be an i386 CentOS 7
+installation, images of which can be found at
+<https://centos.mirror.serveriai.lt/altarch/7/isos/i386/>
 
 ## Kernel Image
 
-The bzimage and roofs.cpio in this directory are from altarch CentOS-7. They are the
-/boot/initramfs-3.10.0-693.5.2.el7.centos.plus.i686.img
-/boot/vmlinuz-3.10.0-693.5.2.el7.centos.plus.i686
+The `bzimage` and `roofs.cpio` in this directory are from altarch CentOS-7. They
+are from the file
+
+    /boot/initramfs-3.10.0-693.5.2.el7.centos.plus.i686.img
+    /boot/vmlinuz-3.10.0-693.5.2.el7.centos.plus.i686
+
 From an i386 CentOS-7 installation. You should be able to replace these with the
-equivalent files from any i386 CentOS-7 installation, regardless of the precise version,
-although you should not need to do this as this kernel/initramfs should be compatible with
-any installation.
+equivalent files from any i386 CentOS-7 installation, regardless of the precise
+version, although you should not need to do this as this `kernel/initramfs`
+should be compatible with any installation.
 
 ## Kernel Command Line
 
-Assuming a default installation of CentOS the command line passed to the Linux kernel.
-In the case where you provided a custom name for your root partitions, or if
-something changes in later CentOS versions, then this needs to be updated from the
-command line in the grub configuration of your actual installation
+Assuming a default installation of CentOS the command line passed to the Linux
+kernel. In the case where you provided a custom name for your root partitions,
+or if something changes in later CentOS versions, then this needs to be updated
+from the command line in the grub configuration of your actual installation
 
 ## Booting the VMM
 
-After building you will have two files in the images/ directory, a kernel- and a capdl-.
-These need to be booted with a multiboot compatible loader, with the capdl- image passed
-as a boot module. This can be done with with a PXE based network loader, or by adding to
-the grub menu of the installed CentOS.
+After building you will have two files in the `images/` directory, a `kernel-`
+and a `capdl-`. These need to be booted with a multiboot compatible loader, with
+the `capdl-` image passed as a boot module. This can be done with with a PXE
+based network loader, or by adding to the grub menu of the installed CentOS.
 
 ## Hardware Configuration
 
-The component specification assumes that the cma34cr is close to its default configuration,
-with the exception that the SATA controller has been placed into legacy IDE mode instead of
-its default AHCI mode.
+The component specification assumes that the `cma34cr` is close to its default
+configuration, with the exception that the SATA controller has been placed into
+legacy IDE mode instead of its default AHCI mode.


### PR DESCRIPTION
- Forces node-24 actions to remove node-20 warnings.
- Fix link in Centos README and reformat

Test with: https://github.com/seL4/seL4/pull/1636