### PR TITLE
aeslib: declare missing function in header

### DIFF
--- a/apps/Arm/odroid_vm/components/pilot/src/aeslib/gf128mul.h
+++ b/apps/Arm/odroid_vm/components/pilot/src/aeslib/gf128mul.h
@@ -177,7 +177,8 @@ typedef enum { REVERSE_NONE = 0, REVERSE_BITS = 1, REVERSE_BYTES = 2 } transform
 
 void convert_representation(gf_t dest, const gf_t source, transform rev);
 
-void gf_mul(gf_t a, const gf_t b);      /* slow field multiply  */  
+void gf_mul(gf_t a, const gf_t b);      /* slow field multiply  */
+void gf_mulTMD(gf_t a, const gf_t b);   /* slow field multiply  */
 
 /* types and calls for 64k table driven field multiplier        */
 


### PR DESCRIPTION
gcc 14 is flagging the `gf_mulTMD` calls in `gcm.c` as implicit function declarations, because it is not declared in the header.

Most likely gf_mul was intended to be gf_mulTMD, but the caller is directly calling gf_mulTMD and adding gf_mulTMD to the header is the minimal change.

Test with: https://github.com/seL4/projects_libs/pull/26 and https://github.com/seL4/global-components/pull/54
