### PR TITLE
zmq_samples: add missing headers

### DIFF
--- a/apps/x86/zmq_samples/src/user/pipeline/sink.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/sink.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 
 int main (int argc, char *argv[])
 {

--- a/apps/x86/zmq_samples/src/user/pipeline/sink.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/sink.c
@@ -14,61 +14,62 @@
 #include <string.h>
 #include <sys/time.h>
 
-int main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 
     const char *bind_to;
     int roundtrip_count;
     if (argc != 3) {
-        printf ("usage: %s <bind-to> "
-                "<roundtrip-count>\n", argv[0]);
+        printf("usage: %s <bind-to> "
+               "<roundtrip-count>\n", argv[0]);
         return -1;
     }
     bind_to = argv[1];
-    roundtrip_count = atoi (argv[2]);
+    roundtrip_count = atoi(argv[2]);
 
     //  Prepare our context and socket
-    void *context = zmq_ctx_new ();
-    void *receiver = zmq_socket (context, ZMQ_PULL);
-    zmq_bind (receiver, bind_to);
+    void *context = zmq_ctx_new();
+    void *receiver = zmq_socket(context, ZMQ_PULL);
+    zmq_bind(receiver, bind_to);
 
     //  Wait for start of batch
     char buffer [256];
-    int size = zmq_recv (receiver, buffer, 255, 0);
+    int size = zmq_recv(receiver, buffer, 255, 0);
     if (size == -1) {
         printf("Got eof");
         return -1;
     }
     //  Start our clock now
     struct timeval tv;
-    gettimeofday (&tv, NULL);
-    int64_t start_time =  (int64_t) (tv.tv_sec * 1000 + tv.tv_usec / 1000);
+    gettimeofday(&tv, NULL);
+    int64_t start_time = (int64_t)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
 
     //  Process 100 confirmations
     int task_nbr;
     for (task_nbr = 0; task_nbr < roundtrip_count; task_nbr++) {
         char buffer [256];
-        int size = zmq_recv (receiver, buffer, 255, 0);
+        int size = zmq_recv(receiver, buffer, 255, 0);
         if (size == -1) {
             printf("Got eof");
             return -1;
         }
         buffer[size] = '\0';
         char *string = buffer;
-        if ((task_nbr / 10) * 10 == task_nbr)
-            printf (":");
-        else
-            printf (".");
-        fflush (stdout);
+        if ((task_nbr / 10) * 10 == task_nbr) {
+            printf(":");
+        } else {
+            printf(".");
+        }
+        fflush(stdout);
     }
     //  Calculate and report duration of batch
-    gettimeofday (&tv, NULL);
-    int64_t end_time =  (int64_t) (tv.tv_sec * 1000 + tv.tv_usec / 1000);
+    gettimeofday(&tv, NULL);
+    int64_t end_time = (int64_t)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
 
-    printf ("Total elapsed time: %d msec\n",
-        (int) (end_time - start_time));
+    printf("Total elapsed time: %d msec\n",
+           (int)(end_time - start_time));
 
-    zmq_close (receiver);
-    zmq_ctx_destroy (context);
+    zmq_close(receiver);
+    zmq_ctx_destroy(context);
     return 0;
 }

--- a/apps/x86/zmq_samples/src/user/pipeline/source.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/source.c
@@ -15,40 +15,40 @@
 
 #define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 
-int main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     const char *bind_to1;
     const char *bind_to2;
 
     int roundtrip_count;
     if (argc != 4) {
-        printf ("usage: %s <bind-to> <bind-to>"
-                "<roundtrip-count>\n", argv[0]);
+        printf("usage: %s <bind-to> <bind-to>"
+               "<roundtrip-count>\n", argv[0]);
         return -1;
     }
     bind_to1 = argv[1];
     bind_to2 = argv[2];
-    roundtrip_count = atoi (argv[3]);
+    roundtrip_count = atoi(argv[3]);
 
-    void *context = zmq_ctx_new ();
+    void *context = zmq_ctx_new();
 
     //  Socket to send messages on
-    void *sender = zmq_socket (context, ZMQ_PUSH);
-    zmq_bind (sender, bind_to1);
+    void *sender = zmq_socket(context, ZMQ_PUSH);
+    zmq_bind(sender, bind_to1);
 
     //  Socket to send start of batch message on
-    void *sink = zmq_socket (context, ZMQ_PUSH);
-    zmq_connect (sink, bind_to2);
+    void *sink = zmq_socket(context, ZMQ_PUSH);
+    zmq_connect(sink, bind_to2);
 
-     // printf ("Press Enter when the workers are ready: ");
-     // getchar ();
-    printf ("Sending tasks to workers…\n");
+    // printf ("Press Enter when the workers are ready: ");
+    // getchar ();
+    printf("Sending tasks to workers…\n");
 
     //  The first message is "0" and signals start of batch
-    zmq_send (sink, "0", 2, 0);
+    zmq_send(sink, "0", 2, 0);
 
     //  Initialize random number generator
-    srandom ((unsigned) time (NULL));
+    srandom((unsigned) time(NULL));
 
     //  Send 100 tasks
     int task_nbr;
@@ -56,16 +56,16 @@ int main (int argc, char *argv[])
     for (task_nbr = 0; task_nbr < roundtrip_count; task_nbr++) {
         int workload;
         //  Random workload from 1 to 100msecs
-        workload = randof (100) + 1;
+        workload = randof(100) + 1;
         total_msec += workload;
         char string [10];
-        sprintf (string, "%d", workload);
-        zmq_send (sender, string, strlen(string), 0);
+        sprintf(string, "%d", workload);
+        zmq_send(sender, string, strlen(string), 0);
     }
-    printf ("Total expected cost: %d msec\n", total_msec);
+    printf("Total expected cost: %d msec\n", total_msec);
 
-    zmq_close (sink);
-    zmq_close (sender);
-    zmq_ctx_destroy (context);
+    zmq_close(sink);
+    zmq_close(sender);
+    zmq_ctx_destroy(context);
     return 0;
 }

--- a/apps/x86/zmq_samples/src/user/pipeline/source.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/source.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 

--- a/apps/x86/zmq_samples/src/user/pipeline/worker.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/worker.c
@@ -16,49 +16,49 @@
 #include <string.h>
 #include <time.h>
 
-int main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     const char *bind_to1;
     const char *bind_to2;
 
     int roundtrip_count;
     if (argc != 3) {
-        printf ("usage: %s <bind-to> <bind-to>\n", argv[0]);
+        printf("usage: %s <bind-to> <bind-to>\n", argv[0]);
         return -1;
     }
     bind_to1 = argv[1];
     bind_to2 = argv[2];
 
     //  Socket to receive messages on
-    void *context = zmq_ctx_new ();
-    void *receiver = zmq_socket (context, ZMQ_PULL);
-    zmq_connect (receiver, bind_to1);
+    void *context = zmq_ctx_new();
+    void *receiver = zmq_socket(context, ZMQ_PULL);
+    zmq_connect(receiver, bind_to1);
 
     //  Socket to send messages to
-    void *sender = zmq_socket (context, ZMQ_PUSH);
-    zmq_connect (sender, bind_to2);
+    void *sender = zmq_socket(context, ZMQ_PUSH);
+    zmq_connect(sender, bind_to2);
 
     //  Process tasks forever
     while (1) {
         char buffer [256];
-        int size = zmq_recv (receiver, buffer, 255, 0);
+        int size = zmq_recv(receiver, buffer, 255, 0);
         if (size == -1) {
             printf("Got eof");
             return -1;
         }
         buffer[size] = '\0';
         char *string = buffer;
-        printf ("%s.", string);     //  Show progress
-        fflush (stdout);
+        printf("%s.", string);      //  Show progress
+        fflush(stdout);
         struct timespec t;
-        t.tv_sec  =  atoi (string) / 1000;
-        t.tv_nsec = (atoi (string) % 1000) * 1000000;
-        nanosleep (&t, NULL);
+        t.tv_sec  =  atoi(string) / 1000;
+        t.tv_nsec = (atoi(string) % 1000) * 1000000;
+        nanosleep(&t, NULL);
 
-        zmq_send (sender, "", 1, 0);        //  Send results to sink
+        zmq_send(sender, "", 1, 0);         //  Send results to sink
     }
-    zmq_close (receiver);
-    zmq_close (sender);
-    zmq_ctx_destroy (context);
+    zmq_close(receiver);
+    zmq_close(sender);
+    zmq_ctx_destroy(context);
     return 0;
 }

--- a/apps/x86/zmq_samples/src/user/pipeline/worker.c
+++ b/apps/x86/zmq_samples/src/user/pipeline/worker.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 int main (int argc, char *argv[])
 {

--- a/apps/x86/zmq_samples/src/user/pubsub/pub.c
+++ b/apps/x86/zmq_samples/src/user/pubsub/pub.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 #define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 
 int main (int argc, char *argv[])

--- a/apps/x86/zmq_samples/src/user/pubsub/pub.c
+++ b/apps/x86/zmq_samples/src/user/pubsub/pub.c
@@ -15,7 +15,7 @@
 #include <unistd.h>
 #define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 
-int main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     const char *bind_to;
     int roundtrip_count;
@@ -27,60 +27,60 @@ int main (int argc, char *argv[])
     zmq_msg_t msg;
 
     if (argc != 4) {
-        printf ("usage: %s <bind-to> <message-size> "
-                "<roundtrip-count>\n", argv[0]);
+        printf("usage: %s <bind-to> <message-size> "
+               "<roundtrip-count>\n", argv[0]);
         return -1;
     }
     bind_to = argv[1];
-    message_size = atoi (argv[2]);
-    roundtrip_count = atoi (argv[3]);
+    message_size = atoi(argv[2]);
+    roundtrip_count = atoi(argv[3]);
 
-    ctx = zmq_init (1);
+    ctx = zmq_init(1);
     if (!ctx) {
-        printf ("error in zmq_init: %s\n", zmq_strerror (errno));
+        printf("error in zmq_init: %s\n", zmq_strerror(errno));
         return -1;
     }
 
-    s = zmq_socket (ctx, ZMQ_PUB);
+    s = zmq_socket(ctx, ZMQ_PUB);
     if (!s) {
-        printf ("error in zmq_socket: %s\n", zmq_strerror (errno));
+        printf("error in zmq_socket: %s\n", zmq_strerror(errno));
         return -1;
     }
-    rc = zmq_bind (s, bind_to);
+    rc = zmq_bind(s, bind_to);
     if (rc != 0) {
-        printf ("error in zmq_bind: %s\n", zmq_strerror (errno));
+        printf("error in zmq_bind: %s\n", zmq_strerror(errno));
         return -1;
     }
 
 
-    srandom ((unsigned) time (NULL));
+    srandom((unsigned) time(NULL));
     printf("%d\n", roundtrip_count);
-    for (int i=0; i < roundtrip_count; i++) {
+    for (int i = 0; i < roundtrip_count; i++) {
         //  Get values that will fool the boss
         //printf("Sending\n");
         int zipcode, temperature, relhumidity;
-        zipcode     = randof (100000);
-        temperature = randof (215) - 80;
-        relhumidity = randof (50) + 10;
+        zipcode     = randof(100000);
+        temperature = randof(215) - 80;
+        relhumidity = randof(50) + 10;
 
         //  Send message to all subscribers
         char update [20];
-        sprintf (update, "%05d %d %d %d", zipcode, temperature, relhumidity, i);
-        int len = zmq_send (s, update, strnlen(update, 20), 0);
+        sprintf(update, "%05d %d %d %d", zipcode, temperature, relhumidity, i);
+        int len = zmq_send(s, update, strnlen(update, 20), 0);
         //printf("%d\n", len);
         sleep(1);
     }
 
 
-    rc = zmq_close (s);
+    rc = zmq_close(s);
     if (rc != 0) {
-        printf ("error in zmq_close: %s\n", zmq_strerror (errno));
+        printf("error in zmq_close: %s\n", zmq_strerror(errno));
         return -1;
     }
 
-    rc = zmq_ctx_term (ctx);
+    rc = zmq_ctx_term(ctx);
     if (rc != 0) {
-        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
+        printf("error in zmq_ctx_term: %s\n", zmq_strerror(errno));
         return -1;
     }
 


### PR DESCRIPTION
Add missing headers for the functions `time`, `gettimeofday`, `sleep`, and `nanosleep`.

This should fix the build for the x86 `zmq_samples` example.
